### PR TITLE
Endpoint to cron jobs, not scheduled internally

### DIFF
--- a/backend/core/src/main/java/decidish/com/core/CoreApplication.java
+++ b/backend/core/src/main/java/decidish/com/core/CoreApplication.java
@@ -2,10 +2,9 @@ package decidish.com.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
+// @EnableScheduling // Managed externally via JobController
 public class CoreApplication {
 
     public static void main(String[] args) {

--- a/backend/core/src/main/java/decidish/com/core/controller/JobController.java
+++ b/backend/core/src/main/java/decidish/com/core/controller/JobController.java
@@ -1,0 +1,69 @@
+package decidish.com.core.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import decidish.com.core.scheduler.Scheduler;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+@CrossOrigin(origins = {"http://localhost:3000", "https://qa.decidish.win"}, allowCredentials = "true")
+@AllArgsConstructor
+public class JobController {
+
+    private static final Logger logger = LoggerFactory.getLogger(JobController.class);
+    
+    private final Scheduler scheduler;
+
+    /**
+     * Manually trigger the weekly sync job.
+     * This job updates products for all markets and performs fuzzy matching preprocessing.
+     * Usage: POST /api/v1/jobs/weekly-sync
+     */
+    @PostMapping("/weekly-sync")
+    public ResponseEntity<Map<String, String>> triggerWeeklySync() {
+        logger.info("Manual trigger requested for weekly sync job");
+        
+        Map<String, String> response = new HashMap<>();
+        
+        try {
+            // Execute the scheduler task asynchronously to avoid blocking the HTTP response
+            new Thread(() -> {
+                try {
+                    scheduler.weeklySync();
+                } catch (Exception e) {
+                    logger.error("Error during manual weekly sync execution: {}", e.getMessage(), e);
+                }
+            }).start();
+            
+            response.put("status", "started");
+            response.put("message", "Weekly sync job has been triggered successfully");
+            logger.info("Weekly sync job triggered successfully");
+            
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            logger.error("Failed to trigger weekly sync job: {}", e.getMessage(), e);
+            response.put("status", "failed");
+            response.put("message", "Failed to trigger weekly sync job: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * Get the status of running jobs.
+     * Usage: GET /api/v1/jobs/status
+     */
+    @GetMapping("/status")
+    public ResponseEntity<Map<String, String>> getJobStatus() {
+        Map<String, String> response = new HashMap<>();
+        response.put("status", "operational");
+        response.put("message", "Job scheduler is running");
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/core/src/main/java/decidish/com/core/scheduler/Scheduler.java
+++ b/backend/core/src/main/java/decidish/com/core/scheduler/Scheduler.java
@@ -1,6 +1,5 @@
 package decidish.com.core.scheduler;
 
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import org.slf4j.Logger;
@@ -20,8 +19,8 @@ public class Scheduler {
 
     private RecipeService recipeService;
 
-    @Scheduled(cron = "${cron.weekly-sync}")
-    // @Scheduled(cron = "${cron.quick-sync}")
+    // Managed externally via JobController
+    // @Scheduled(cron = "${cron.weekly-sync}") 
     public void weeklySync() {
 
         // sync products for all markets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to manually trigger weekly synchronization tasks and monitor operational status
  * Weekly data sync now executes on-demand via API calls instead of automatic schedules

* **Refactor**
  * Transitioned background synchronization from automatic to manual, API-triggered execution model

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->